### PR TITLE
Support transactional SPI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,5 +24,8 @@ structopt = { version = "0.2.15", optional = true }
 simplelog = { version = "0.5.3", optional = true }
 
 [patch.crates-io]
-embedded-hal = { git = "https://github.com/ryankurte/embedded-hal.git", branch = "feature/spi-i2c-transactions" }
-linux-embedded-hal = { git = "https://github.com/ryankurte/linux-embedded-hal.git", branch = "feature/transactional" }
+#embedded-hal = { git = "https://github.com/ryankurte/embedded-hal.git", branch = "feature/spi-i2c-transactions" }
+#linux-embedded-hal = { git = "https://github.com/ryankurte/linux-embedded-hal.git", branch = "feature/transactional" }
+
+embedded-hal = { path = "../embedded-hal" }
+linux-embedded-hal = { path = "../linux-embedded-hal" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT"
 mock = []
 ffi = [ "libc" ]
 utils = [ "toml", "structopt", "serde", "simplelog", "linux-embedded-hal" ]
-default = [ "mock", "ffi", "utils" ]
+default = [ "mock", "utils" ]
 
 [dependencies]
 embedded-hal = { version = "0.2.3", features = ["unproven"] }
@@ -22,3 +22,7 @@ serde = { version = "1.0.91", features = ["derive"], optional = true }
 toml = { version = "0.5.1", optional = true }
 structopt = { version = "0.2.15", optional = true }
 simplelog = { version = "0.5.3", optional = true }
+
+[patch.crates-io]
+embedded-hal = { git = "https://github.com/ryankurte/embedded-hal.git", branch = "feature/spi-i2c-transactions" }
+linux-embedded-hal = { git = "https://github.com/ryankurte/linux-embedded-hal.git", branch = "feature/transactional" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@ pub trait Transactional {
     fn spi_write(&mut self, prefix: &[u8], data: &[u8]) -> Result<(), Self::Error>;
 }
 
-pub type Transaction<'a> = embedded_hal::blocking::spi::Operation<'a>;
+pub type Transaction<'a> = embedded_hal::blocking::spi::Operation<'a, u8>;
 
 /// Busy trait for peripherals that support a busy signal
 pub trait Busy {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,26 +54,9 @@ pub trait Transactional {
 
     /// Write writes the prefix buffer then writes the output buffer
     fn spi_write(&mut self, prefix: &[u8], data: &[u8]) -> Result<(), Self::Error>;
-
-    /// Transfer writes the outgoing buffer while reading into the incoming buffer
-    /// note that outgoing and incoming must have the same length
-    //fn transfer(&mut self, outgoing: &[u8], incoming: &mut [u8]) -> Result<(), Self::Error>;
-
-    /// Exec allows 'Transaction' objects to be chained together into a single transaction
-    fn spi_exec(&mut self, transactions: &mut [Transaction]) -> Result<(), Self::Error>;
 }
 
-/// Transaction enum defines possible SPI transactions
-#[derive(Debug, PartialEq)]
-pub enum Transaction<'a> {
-    // Write the supplied buffer to the peripheral
-    Write(&'a [u8]),
-    // Read from the peripheral into the supplied buffer
-    Read(&'a mut [u8]),
-    // Write the first buffer while reading into the second
-    // This behaviour is actually just the same as Read
-    //Transfer((&'a [u8], &'a mut [u8]))
-}
+pub type Transaction<'a> = embedded_hal::blocking::spi::Operation<'a>;
 
 /// Busy trait for peripherals that support a busy signal
 pub trait Busy {

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -137,8 +137,8 @@ pub enum MockExec {
     SpiTransfer(Vec<u8>, Vec<u8>),
 }
 
-impl<'a> From<&spi::Operation<'a>> for MockExec {
-    fn from(t: &spi::Operation<'a>) -> Self {
+impl<'a> From<&spi::Operation<'a, u8>> for MockExec {
+    fn from(t: &spi::Operation<'a, u8>) -> Self {
         match t {
             spi::Operation::Write(ref d) => {
                 MockExec::SpiWrite(d.to_vec())
@@ -389,12 +389,12 @@ impl spi::Write<u8> for Spi {
     }
 }
 
-impl spi::Transactional for Spi {
+impl spi::Transactional<u8> for Spi {
     type Error = Error<(), ()>;
 
     fn exec<'a, O>(&mut self, mut operations: O) -> Result<(), Self::Error>
     where
-        O: AsMut<[spi::Operation<'a>]> 
+        O: AsMut<[spi::Operation<'a, u8>]> 
     {
         let mut i = self.inner.lock().unwrap();
         let index = i.index;

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -41,8 +41,10 @@ pub struct Delay {
 #[derive(Clone, Debug, PartialEq)]
 pub enum MockTransaction {
     None,
+
     SpiWrite(Id, Vec<u8>, Vec<u8>),
     SpiRead(Id, Vec<u8>, Vec<u8>),
+
     SpiExec(Id, Vec<MockExec>),
 
     Busy(Id, PinState),
@@ -132,21 +134,17 @@ impl MockTransaction {
 #[derive(Clone, Debug, PartialEq)]
 pub enum MockExec {
     SpiWrite(Vec<u8>),
-    SpiRead(Vec<u8>),
+    SpiTransfer(Vec<u8>, Vec<u8>),
 }
 
-impl<'a> From<&Transaction<'a>> for MockExec {
-    fn from(t: &Transaction<'a>) -> Self {
+impl<'a> From<&spi::Operation<'a>> for MockExec {
+    fn from(t: &spi::Operation<'a>) -> Self {
         match t {
-            Transaction::Read(ref d) => {
-                let mut v = Vec::with_capacity(d.len());
-                v.copy_from_slice(d);
-                MockExec::SpiRead(v)
+            spi::Operation::Write(ref d) => {
+                MockExec::SpiWrite(d.to_vec())
             }
-            Transaction::Write(ref d) => {
-                let mut v = Vec::with_capacity(d.len());
-                v.copy_from_slice(d);
-                MockExec::SpiWrite(v)
+            spi::Operation::WriteRead(ref o, ref i) => {
+                MockExec::SpiTransfer(o.to_vec(), i.to_vec())
             }
         }
     }
@@ -276,39 +274,6 @@ impl Transactional for Spi {
 
         Ok(())
     }
-
-    /// Execute the provided transactions
-    fn spi_exec(&mut self, transactions: &mut [Transaction]) -> Result<(), Self::Error> {
-        let mut i = self.inner.lock().unwrap();
-        let index = i.index;
-
-        // Save actual calls
-        let t: Vec<MockExec> = transactions
-            .iter()
-            .map(|ref v| MockExec::from(*v))
-            .collect();
-        i.actual.push(MockTransaction::SpiExec(self.id, t));
-
-        // Load expected reads
-        if let MockTransaction::SpiExec(_id, e) = &i.expected[index] {
-            for i in 0..transactions.len() {
-                let t = &mut transactions[i];
-                let x = e.get(i);
-
-                match (t, x) {
-                    (Transaction::Read(ref mut v), Some(MockExec::SpiRead(d))) => {
-                        v.copy_from_slice(&d)
-                    }
-                    _ => (),
-                }
-            }
-        }
-
-        // Update expectation index
-        i.index += 1;
-
-        Ok(())
-    }
 }
 
 impl Busy for Spi {
@@ -416,6 +381,51 @@ impl spi::Write<u8> for Spi {
 
         // Save actual call
         i.actual.push(MockTransaction::Write(self.id, data.into()));
+
+        // Update expectation index
+        i.index += 1;
+
+        Ok(())
+    }
+}
+
+impl spi::Transactional for Spi {
+    type Error = Error<(), ()>;
+
+    fn exec<'a, O>(&mut self, mut operations: O) -> Result<(), Self::Error>
+    where
+        O: AsMut<[spi::Operation<'a>]> 
+    {
+        let mut i = self.inner.lock().unwrap();
+        let index = i.index;
+
+        // Save actual calls
+        let t: Vec<MockExec> = operations
+            .as_mut()
+            .iter()
+            .map(|ref v| MockExec::from(*v))
+            .collect();
+        i.actual.push(MockTransaction::SpiExec(self.id, t));
+
+        let transactions = operations.as_mut();
+
+        // Load expected reads
+        if let MockTransaction::SpiExec(_id, e) = &i.expected[index] {
+            for i in 0..transactions.len() {
+                let t = &mut transactions[i];
+                let x = e.get(i);
+
+                match (t, x) {
+                    (Transaction::WriteRead(ref t_out, ref mut t_in), Some(MockExec::SpiTransfer(x_out, x_in))) => {
+                        t_in.copy_from_slice(&x_in)
+                    },
+                    (Transaction::Write(ref t_out), Some(MockExec::SpiWrite(ref x_out))) => {
+                        //assert_eq!(t_out, x_out);
+                    },
+                    _ => (),
+                }
+            }
+        }
 
         // Update expectation index
         i.index += 1;

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -416,10 +416,10 @@ impl spi::Transactional for Spi {
                 let x = e.get(i);
 
                 match (t, x) {
-                    (Transaction::WriteRead(ref t_out, ref mut t_in), Some(MockExec::SpiTransfer(x_out, x_in))) => {
+                    (Transaction::WriteRead(ref _t_out, ref mut t_in), Some(MockExec::SpiTransfer(_x_out, x_in))) => {
                         t_in.copy_from_slice(&x_in)
                     },
-                    (Transaction::Write(ref t_out), Some(MockExec::SpiWrite(ref x_out))) => {
+                    (Transaction::Write(ref _t_out), Some(MockExec::SpiWrite(ref _x_out))) => {
                         //assert_eq!(t_out, x_out);
                     },
                     _ => (),

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -35,7 +35,7 @@ pub struct Wrapper<Spi, SpiError, CsPin, BusyPin, ReadyPin, ResetPin, PinError, 
 impl<Spi, SpiError, CsPin, BusyPin, ReadyPin, ResetPin, PinError, Delay>
     Wrapper<Spi, SpiError, CsPin, BusyPin, ReadyPin, ResetPin, PinError, Delay>
 where
-    Spi: Transfer<u8, Error = SpiError> + Write<u8, Error = SpiError> + spi::Transactional<Error = SpiError>,
+    Spi: Transfer<u8, Error = SpiError> + Write<u8, Error = SpiError> + spi::Transactional<u8, Error = SpiError>,
     CsPin: OutputPin<Error = PinError>,
     Delay: DelayMs<u32>,
 {
@@ -262,16 +262,16 @@ where
     }
 }
 
-impl<Spi, SpiError, CsPin, BusyPin, ReadyPin, ResetPin, PinError, Delay> spi::Transactional
+impl<Spi, SpiError, CsPin, BusyPin, ReadyPin, ResetPin, PinError, Delay> spi::Transactional<u8>
     for Wrapper<Spi, SpiError, CsPin, BusyPin, ReadyPin, ResetPin, PinError, Delay>
 where
-    Spi: spi::Transactional<Error = SpiError>,
+    Spi: spi::Transactional<u8, Error = SpiError>,
 {
     type Error = SpiError;
 
     fn exec<'a, O>(&mut self, operations: O) -> Result<(), Self::Error>
     where
-        O: AsMut<[Operation<'a>]> 
+        O: AsMut<[Operation<'a, u8>]> 
     {
         spi::Transactional::exec(&mut self.spi, operations)
     }

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -3,7 +3,7 @@
 //! and `embedded_hal::digital::v2::OutputPin` to provide a transactional API for SPI transactions.
 
 use embedded_hal::blocking::delay::DelayMs;
-use embedded_hal::blocking::spi::{self, Transfer, Write, Operation, Transactional as _};
+use embedded_hal::blocking::spi::{self, Transfer, Write, Operation};
 use embedded_hal::digital::v2::{InputPin, OutputPin};
 
 use crate::{Busy, Error, PinState, Ready, Reset, Transactional};
@@ -114,7 +114,7 @@ where
 impl<Spi, SpiError, CsPin, BusyPin, ReadyPin, ResetPin, PinError, Delay> Transactional
     for Wrapper<Spi, SpiError, CsPin, BusyPin, ReadyPin, ResetPin, PinError, Delay>
 where
-    Spi: Transfer<u8, Error = SpiError> + Write<u8, Error = SpiError> + spi::Transactional<Error = SpiError>,
+    Spi: Transfer<u8, Error = SpiError> + Write<u8, Error = SpiError>,
     CsPin: OutputPin<Error = PinError>,
     Delay: DelayMs<u32>,
 {
@@ -236,7 +236,7 @@ where
 impl<Spi, SpiError, CsPin, BusyPin, ReadyPin, ResetPin, PinError, Delay> Transfer<u8>
     for Wrapper<Spi, SpiError, CsPin, BusyPin, ReadyPin, ResetPin, PinError, Delay>
 where
-    Spi: Transfer<u8, Error = SpiError> + Write<u8, Error = SpiError> + spi::Transactional<Error = SpiError>,
+    Spi: Transfer<u8, Error = SpiError>,
 {
     type Error = SpiError;
 
@@ -252,7 +252,7 @@ where
 impl<Spi, SpiError, CsPin, BusyPin, ReadyPin, ResetPin, PinError, Delay> Write<u8>
     for Wrapper<Spi, SpiError, CsPin, BusyPin, ReadyPin, ResetPin, PinError, Delay>
 where
-    Spi: Transfer<u8, Error = SpiError> + Write<u8, Error = SpiError> + spi::Transactional<Error = SpiError>,
+    Spi: Write<u8, Error = SpiError>,
 {
     type Error = SpiError;
 
@@ -265,11 +265,11 @@ where
 impl<Spi, SpiError, CsPin, BusyPin, ReadyPin, ResetPin, PinError, Delay> spi::Transactional
     for Wrapper<Spi, SpiError, CsPin, BusyPin, ReadyPin, ResetPin, PinError, Delay>
 where
-    Spi: Transfer<u8, Error = SpiError> + Write<u8, Error = SpiError> + spi::Transactional<Error = SpiError>,
+    Spi: spi::Transactional<Error = SpiError>,
 {
     type Error = SpiError;
 
-    fn exec<'a, O>(&mut self, mut operations: O) -> Result<(), Self::Error>
+    fn exec<'a, O>(&mut self, operations: O) -> Result<(), Self::Error>
     where
         O: AsMut<[Operation<'a>]> 
     {


### PR DESCRIPTION
Blocked on https://github.com/rust-embedded/embedded-hal/pull/178

TODO: drop spi::Write and spi::Transfer bounds when they can be replaced with a spi::Transactional::exec call