### PR TITLE
Adding HAL to support abstract underlying devices

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,15 +25,15 @@ serde = { version = "1.0.91", features = ["derive"], optional = true }
 toml = { version = "0.5.1", optional = true }
 structopt = { version = "0.3.11", optional = true }
 simplelog = { version = "0.5.3", optional = true }
-driver-cp2130 = { version = "0.3.1", optional = true }
+driver-cp2130 = { version = "0.4.0", optional = true }
 
 
 [patch.crates-io]
-embedded-hal = { git = "https://github.com/ryankurte/embedded-hal", branch = "feature/spi-i2c-transactions" }
-linux-embedded-hal = { git = "https://github.com/ryankurte/linux-embedded-hal.git", branch = "feature/transactional" }
-driver-cp2130 = { git = "https://github.com/ryankurte/rust-driver-cp2130", branch = "fix/static-refs" }
+embedded-hal = { git = "https://github.com/ryankurte/embedded-hal", branch = "feature/spi-transactions" }
+#linux-embedded-hal = { git = "https://github.com/ryankurte/linux-embedded-hal.git", branch = "feature/spi-transactions" }
+driver-cp2130 = { git = "https://github.com/ryankurte/rust-driver-cp2130", branch = "master" }
 
 
 #driver-cp2130 = { path = "../rust-driver-cp2130", optional=true }
 #embedded-hal = { path = "../embedded-hal" }
-#linux-embedded-hal = { path = "../linux-embedded-hal" }
+linux-embedded-hal = { path = "../linux-embedded-hal" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,11 @@ license = "MIT"
 [features]
 mock = []
 ffi = [ "libc" ]
-utils = [ "toml", "structopt", "serde", "simplelog", "linux-embedded-hal" ]
+utils = [ "hal" ]
 hal = [ "toml", "structopt", "serde", "simplelog" ]
 hal-cp2130 = [ "driver-cp2130" ]
 hal-linux = [ "linux-embedded-hal" ]
-default = [ "mock", "hal", "hal-cp2130" ]
+default = [ "mock", "hal", "hal-cp2130", "hal-linux" ]
 
 [dependencies]
 embedded-hal = { version = "0.2.3", features = ["unproven"] }
@@ -25,11 +25,13 @@ serde = { version = "1.0.91", features = ["derive"], optional = true }
 toml = { version = "0.5.1", optional = true }
 structopt = { version = "0.2.15", optional = true }
 simplelog = { version = "0.5.3", optional = true }
-#driver-cp2130 = { version = "0.3.1", optional = true }
-driver-cp2130 = { path = "../rust-driver-cp2130", optional=true }
+driver-cp2130 = { version = "0.3.1", optional = true }
+
 
 [patch.crates-io]
-#embedded-hal = { git = "https://github.com/ryankurte/embedded-hal", branch = "feature/spi-i2c-transactions" }
-#linux-embedded-hal = { git = "https://github.com/ryankurte/linux-embedded-hal.git", branch = "feature/transactional" }
+embedded-hal = { git = "https://github.com/ryankurte/embedded-hal", branch = "feature/spi-i2c-transactions" }
+driver-cp2130 = { git = "https://github.com/ryankurte/rust-driver-cp2130", branch = "fix/static-refs" }
 
-embedded-hal = { path = "../embedded-hal" }
+#linux-embedded-hal = { git = "https://github.com/ryankurte/linux-embedded-hal.git", branch = "feature/transactional" }
+#driver-cp2130 = { path = "../rust-driver-cp2130", optional=true }
+#embedded-hal = { path = "../embedded-hal" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,10 @@ license = "MIT"
 mock = []
 ffi = [ "libc" ]
 utils = [ "toml", "structopt", "serde", "simplelog", "linux-embedded-hal" ]
-default = [ "mock", "ffi", "utils" ]
+hal = [ "toml", "structopt", "serde", "simplelog" ]
+hal-cp2130 = [ "driver-cp2130" ]
+hal-linux = [ "linux-embedded-hal" ]
+default = [ "mock", "ffi", "hal", "hal-cp2130" ]
 
 [dependencies]
 embedded-hal = { version = "0.2.3", features = ["unproven"] }
@@ -22,3 +25,10 @@ serde = { version = "1.0.91", features = ["derive"], optional = true }
 toml = { version = "0.5.1", optional = true }
 structopt = { version = "0.2.15", optional = true }
 simplelog = { version = "0.5.3", optional = true }
+#driver-cp2130 = { version = "0.3.1", optional = true }
+driver-cp2130 = { path = "../rust-driver-cp2130", optional=true }
+
+[patch.crates-io]
+embedded-hal = { git = "https://github.com/ryankurte/embedded-hal", branch = "feature/spi-i2c-transactions" }
+
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "embedded-spi"
 description = "Rust embedded driver helper package"
-repository = "https://github.com/ryankurte/rust-embedded-spi"
+repository = "https://github.com/ryankurte/rust-spi-hal"
 version = "0.6.1"
 authors = ["Ryan Kurte <ryankurte@gmail.com>"]
 edition = "2018"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,5 +24,8 @@ structopt = { version = "0.2.15", optional = true }
 simplelog = { version = "0.5.3", optional = true }
 
 [patch.crates-io]
-embedded-hal = { git = "https://github.com/ryankurte/embedded-hal.git", branch = "feature/spi-i2c-transactions" }
-linux-embedded-hal = { git = "https://github.com/ryankurte/linux-embedded-hal.git", branch = "feature/transactional" }
+#embedded-hal = { git = "https://github.com/ryankurte/embedded-hal.git", branch = "feature/spi-i2c-transactions" }
+#linux-embedded-hal = { git = "https://github.com/ryankurte/linux-embedded-hal.git", branch = "feature/transactional" }
+
+embedded-hal = { path = "../embedded-hal" }
+linux-embedded-hal = { path = "../linux-embedded-hal" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT"
 mock = []
 ffi = [ "libc" ]
 utils = [ "toml", "structopt", "serde", "simplelog", "linux-embedded-hal" ]
-default = [ "mock", "ffi", "utils" ]
+default = [ "mock", "utils" ]
 
 [dependencies]
 embedded-hal = { version = "0.2.3", features = ["unproven"] }
@@ -22,3 +22,7 @@ serde = { version = "1.0.91", features = ["derive"], optional = true }
 toml = { version = "0.5.1", optional = true }
 structopt = { version = "0.2.15", optional = true }
 simplelog = { version = "0.5.3", optional = true }
+
+[patch.crates-io]
+embedded-hal = { git = "https://github.com/ryankurte/embedded-hal.git", branch = "feature/spi-i2c-transactions" }
+linux-embedded-hal = { git = "https://github.com/ryankurte/linux-embedded-hal.git", branch = "feature/transactional" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,15 +23,17 @@ libc = { version = "0.2.54", optional = true }
 log = "0.4.6"
 serde = { version = "1.0.91", features = ["derive"], optional = true }
 toml = { version = "0.5.1", optional = true }
-structopt = { version = "0.2.15", optional = true }
+structopt = { version = "0.3.11", optional = true }
 simplelog = { version = "0.5.3", optional = true }
 driver-cp2130 = { version = "0.3.1", optional = true }
 
 
 [patch.crates-io]
 embedded-hal = { git = "https://github.com/ryankurte/embedded-hal", branch = "feature/spi-i2c-transactions" }
+linux-embedded-hal = { git = "https://github.com/ryankurte/linux-embedded-hal.git", branch = "feature/transactional" }
 driver-cp2130 = { git = "https://github.com/ryankurte/rust-driver-cp2130", branch = "fix/static-refs" }
 
-#linux-embedded-hal = { git = "https://github.com/ryankurte/linux-embedded-hal.git", branch = "feature/transactional" }
+
 #driver-cp2130 = { path = "../rust-driver-cp2130", optional=true }
 #embedded-hal = { path = "../embedded-hal" }
+#linux-embedded-hal = { path = "../linux-embedded-hal" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ serde = { version = "1.0.91", features = ["derive"], optional = true }
 toml = { version = "0.5.1", optional = true }
 structopt = { version = "0.3.11", optional = true }
 simplelog = { version = "0.5.3", optional = true }
-driver-cp2130 = { version = "0.4.0", optional = true }
+driver-cp2130 = { version = "0.3.1", optional = true }
 
 
 [patch.crates-io]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ simplelog = { version = "0.5.3", optional = true }
 driver-cp2130 = { path = "../rust-driver-cp2130", optional=true }
 
 [patch.crates-io]
-embedded-hal = { git = "https://github.com/ryankurte/embedded-hal", branch = "feature/spi-i2c-transactions" }
+#embedded-hal = { git = "https://github.com/ryankurte/embedded-hal", branch = "feature/spi-i2c-transactions" }
 #linux-embedded-hal = { git = "https://github.com/ryankurte/linux-embedded-hal.git", branch = "feature/transactional" }
 
+embedded-hal = { path = "../embedded-hal" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "embedded-spi"
 description = "Rust embedded driver helper package"
 repository = "https://github.com/ryankurte/rust-spi-hal"
-version = "0.6.1"
+version = "0.6.2"
 authors = ["Ryan Kurte <ryankurte@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,10 +30,10 @@ driver-cp2130 = { version = "0.4.0", optional = true }
 
 [patch.crates-io]
 embedded-hal = { git = "https://github.com/ryankurte/embedded-hal", branch = "feature/spi-transactions" }
-#linux-embedded-hal = { git = "https://github.com/ryankurte/linux-embedded-hal.git", branch = "feature/spi-transactions" }
+linux-embedded-hal = { git = "https://github.com/ryankurte/linux-embedded-hal.git", branch = "feature/spi-transactions" }
 driver-cp2130 = { git = "https://github.com/ryankurte/rust-driver-cp2130", branch = "master" }
 
 
 #driver-cp2130 = { path = "../rust-driver-cp2130", optional=true }
 #embedded-hal = { path = "../embedded-hal" }
-linux-embedded-hal = { path = "../linux-embedded-hal" }
+#linux-embedded-hal = { path = "../linux-embedded-hal" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,4 @@ driver-cp2130 = { version = "1.0.0-alpha.0", optional = true, features = ["trans
 [patch.crates-io]
 embedded-hal = { git = "https://github.com/ryankurte/embedded-hal", branch = "feature/spi-transactions" }
 linux-embedded-hal = { git = "https://github.com/ryankurte/linux-embedded-hal.git", branch = "feature/spi-transactions" }
+

--- a/README.md
+++ b/README.md
@@ -1,7 +1,18 @@
-# embedded-spi
+# spi-hal
 
-A helper / testing package for rust-embedded SPI traits and implementations, to try out some more interesting approaches prior to proposing additions to embedded-hal.
-This provides a Transactional SPI interface, as well as a `Wrapper` type to provide this for an SPI and OutputPin implementation, a `Mock` helper for testing drivers based on this, and a set of compatibility shims for c FFI use with dependency injected drivers.
+Previously known as `embedded-spi`, new releases at [crates.io/crates/spi-hal](https://crates.io/crates/spi-hal). 
+A helper package for rust-embedded SPI traits and implementations, including testing approactes prior to proposing additions to embedded-hal.
+
+
+This provides:
+
+- A Transactional SPI interface (https://github.com/rust-embedded/embedded-hal/pull/191)
+- A `CS` pin trait to communicate CS control for drivers
+- a `Wrapper` type to provide this for an SPI and OutputPin implementation
+- a `Hal` that abstracts over a number of SPI implementations to assist with writing driver utilities
+- a `Mock` helper for testing drivers based on this
+- a set of compatibility shims for c FFI use with dependency injected drivers
+
 
 ## Status
 

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -3,11 +3,12 @@
 //! as well as C ffi compatible spi_read and spi_write functions using these context pointers.
 
 use embedded_hal::blocking::delay::DelayMs;
-use embedded_hal::blocking::spi::{Transfer, Write};
+use embedded_hal::blocking::spi::{Transactional};
 use embedded_hal::digital::v2::OutputPin;
 
+use crate::{PrefixWrite, PrefixRead};
 use crate::wrapper::Wrapper;
-use crate::Transactional;
+
 
 /// Mark traits as cursed to provide a `Conv` implementation for FFI use
 pub trait Cursed {}
@@ -48,7 +49,7 @@ impl<Spi, SpiError, CsPin, BusyPin, ReadyPin, ResetPin, PinError, Delay> Cursed
 impl<Spi, SpiError, CsPin, BusyPin, ReadyPin, ResetPin, PinError, Delay>
     Wrapper<Spi, SpiError, CsPin, BusyPin, ReadyPin, ResetPin, PinError, Delay>
 where
-    Spi: Transfer<u8, Error = SpiError> + Write<u8, Error = SpiError>,
+    Spi: Transactional<u8, Error = SpiError>,
     CsPin: OutputPin<Error = PinError>,
     Delay: DelayMs<u32>,
 {
@@ -70,8 +71,9 @@ where
         // Execute command and handle errors
         match s.spi_write(&prefix, &data) {
             Ok(_) => 0,
-            Err(e) => {
-                s.err = Some(e);
+            Err(_e) => {
+                // TODO: removed this from wrapper
+                //s.err = Some(e);
                 -1
             }
         }
@@ -96,8 +98,9 @@ where
         // Execute command and handle errors
         match s.spi_read(&prefix, &mut data) {
             Ok(_) => 0,
-            Err(e) => {
-                s.err = Some(e);
+            Err(_e) => {
+                // TODO: removed this from wrapper
+                //s.err = Some(e);
                 -1
             }
         }

--- a/src/hal/cp2130.rs
+++ b/src/hal/cp2130.rs
@@ -21,6 +21,7 @@ impl TryInto<driver_cp2130::SpiConfig> for SpiConfig {
     }
 }
 
+/// CP2130 `Hal` implementation
 pub struct Cp2130Driver<'a> {
     _cp2130: Cp2130<'a>,
 

--- a/src/hal/cp2130.rs
+++ b/src/hal/cp2130.rs
@@ -3,7 +3,6 @@ use std::convert::{TryFrom, TryInto};
 
 use driver_cp2130::prelude::*;
 
-use embedded_hal::digital::v2::{self as digital};
 use embedded_hal::blocking::spi::{self};
 
 use crate::*;

--- a/src/hal/cp2130.rs
+++ b/src/hal/cp2130.rs
@@ -3,10 +3,8 @@ use std::convert::{TryFrom, TryInto};
 
 use driver_cp2130::prelude::*;
 
-use embedded_hal::blocking::spi::{self};
-
 use crate::*;
-use super::{HalPins, HalPin, HalError, SpiConfig, PinConfig, MaybeGpio};
+use super::{HalInst, HalPins, HalBase, HalSpi, HalInputPin, HalOutputPin, HalError, SpiConfig, PinConfig};
 
 /// Convert a generic SPI config object into a CP2130 object
 impl TryInto<driver_cp2130::SpiConfig> for SpiConfig {
@@ -21,14 +19,11 @@ impl TryInto<driver_cp2130::SpiConfig> for SpiConfig {
 }
 
 /// CP2130 `Hal` implementation
-pub struct Cp2130Driver<'a> {
-    cp2130: Cp2130<'a>,
-    pub spi: Spi<'a>,
-}
+pub struct Cp2130Driver;
 
-impl <'a>Cp2130Driver<'a> {
+impl Cp2130Driver {
     /// Load base CP2130 instance
-    pub fn new(index: usize, spi: &SpiConfig) -> Result<Self, HalError> {
+    pub fn new<'a>(index: usize, spi: &SpiConfig, pins: &PinConfig) -> Result<HalInst<'a>, HalError> {
         // Fetch the matching device and descriptor
         let (device, descriptor) = Manager::device(Filter::default(), index)?;
 
@@ -38,70 +33,35 @@ impl <'a>Cp2130Driver<'a> {
         // Connect SPI
         let spi_config = spi.clone().try_into()?;
         let spi = cp2130.spi(0, spi_config)?;
-
-        // Return object
-        Ok(Self{
-            cp2130,
-            spi,
-        })
-    }
-
-    /// Fetch pin objects from the driver
-    pub fn load_pins(&mut self, pins: &PinConfig) -> Result<HalPins<OutputPin<'a>, InputPin<'a>>, HalError> {
+        
         // Connect pins
 
-        let chip_select = self.cp2130.gpio_out(pins.chip_select as u8, GpioMode::PushPull, GpioLevel::High)?;
+        let chip_select = cp2130.gpio_out(pins.chip_select as u8, GpioMode::PushPull, GpioLevel::High)?;
 
-        let reset = self.cp2130.gpio_out(pins.reset as u8, GpioMode::PushPull, GpioLevel::High)?;
+        let reset = cp2130.gpio_out(pins.reset as u8, GpioMode::PushPull, GpioLevel::High)?;
 
         let busy = match pins.busy {
-            Some(p) => Some(self.cp2130.gpio_in(p as u8)?),
-            None => None,
+            Some(p) => HalInputPin::Cp2130(cp2130.gpio_in(p as u8)?),
+            None => HalInputPin::None,
         };
 
         let ready = match pins.ready {
-            Some(p) => Some(self.cp2130.gpio_in(p as u8)?),
-            None => None,
+            Some(p) => HalInputPin::Cp2130(cp2130.gpio_in(p as u8)?),
+            None => HalInputPin::None,
         };
 
-        let pins = HalPins{
-            cs: HalPin(chip_select),
-            reset: HalPin(reset),
-            busy: MaybeGpio( busy.map(|p| HalPin(p)) ),
-            ready: MaybeGpio( ready.map(|p| HalPin(p)) ),
+        let pins = HalPins {
+            cs: HalOutputPin::Cp2130(chip_select),
+            reset: HalOutputPin::Cp2130(reset),
+            busy,
+            ready,
         };
-        
-        Ok(pins)
+
+        // Return object
+        Ok(HalInst{
+            base: HalBase::Cp2130(cp2130),
+            spi: HalSpi::Cp2130(spi),
+            pins,
+        })
     }
-}
-
-impl <'a> spi::Transfer<u8> for Cp2130Driver<'a>
-{
-    type Error = HalError;
-
-    fn transfer<'w>(&mut self, data: &'w mut [u8]) -> Result<&'w [u8], Self::Error> {
-        let r = self.spi.transfer(data)?;
-        Ok(r)
-    }
-}
-
-impl <'a> spi::Write<u8> for Cp2130Driver<'a>
-{
-    type Error = HalError;
-
-    fn write<'w>(&mut self, data: &[u8]) -> Result<(), Self::Error> {
-        self.spi.write(data)?;
-        Ok(())
-    }
-}
-
-impl <'a> spi::Transactional<u8> for Cp2130Driver<'a> {
-    type Error = HalError;
-
-    fn exec<'b, O>(&mut self, operations: O) -> Result<(), Self::Error>
-    where
-        O: AsMut<[spi::Operation<'b, u8>]> 
-    {
-        crate::wrapper::spi_exec(self, operations)
-    }   
 }

--- a/src/hal/cp2130.rs
+++ b/src/hal/cp2130.rs
@@ -1,0 +1,155 @@
+
+use std::convert::{TryFrom, TryInto};
+
+use driver_cp2130::prelude::*;
+
+use embedded_hal::blocking::delay::{DelayMs, DelayUs};
+use embedded_hal::digital::v2::{InputPin as _, OutputPin as _};
+use embedded_hal::blocking::spi::{Write as SpiWrite, Transfer as SpiTransfer, Transactional as SpiTransactional};
+
+use crate::*;
+use super::{Error, SpiConfig, PinConfig};
+
+
+impl TryInto<driver_cp2130::SpiConfig> for SpiConfig {
+    type Error = Error;
+
+    fn try_into(self) -> Result<driver_cp2130::SpiConfig, Self::Error> {
+        Ok(driver_cp2130::SpiConfig {
+            clock: SpiClock::try_from(self.baud as usize)?,
+            ..driver_cp2130::SpiConfig::default()
+        })
+    }
+}
+
+pub struct Cp2130Driver<'a> {
+    _cp2130: Cp2130<'a>,
+
+    spi: Spi<'a>,
+
+    chip_select: OutputPin<'a>,
+    reset: OutputPin<'a>,
+    busy: Option<InputPin<'a>>,
+    ready: Option<InputPin<'a>>,
+}
+
+impl <'a>Cp2130Driver<'a> {
+    /// Load base CP2130 instance
+    pub fn new(index: usize, spi: &SpiConfig, pins: &PinConfig) -> Result<Self, Error> {
+        // Fetch the matching device and descriptor
+        let (device, descriptor) = Manager::device(Filter::default(), index)?;
+
+        // Create CP2130 object
+        let cp2130 = Cp2130::new(device, descriptor)?;
+
+        // Connect SPI
+        let spi_config = spi.clone().try_into()?;
+        let spi = cp2130.spi(0, spi_config)?;
+
+        // Connect pins
+
+        let chip_select = cp2130.gpio_out(pins.chip_select as u8, GpioMode::PushPull, GpioLevel::High)?;
+
+        let reset = cp2130.gpio_out(pins.reset as u8, GpioMode::PushPull, GpioLevel::High)?;
+
+        let busy = match pins.busy {
+            Some(p) => Some(cp2130.gpio_in(p as u8)?),
+            None => None,
+        };
+
+        let ready = match pins.ready {
+            Some(p) => Some(cp2130.gpio_in(p as u8)?),
+            None => None,
+        };
+
+        // Return object
+        Ok(Self{
+            _cp2130: cp2130,
+            spi,
+            chip_select,
+            reset,
+            busy,
+            ready,
+        })
+    }
+}
+
+impl <'a> Reset for Cp2130Driver<'a> {
+    type Error = Error;
+
+    /// Set the reset pin state
+    fn set_reset(&mut self, state: PinState) -> Result<(), Self::Error> {
+        match state {
+            PinState::High => self.reset.set_high()?,
+            PinState::Low => self.reset.set_low()?,
+        };
+
+        Ok(())
+    }
+}
+
+impl <'a> Busy for Cp2130Driver<'a> {
+    type Error = Error;
+
+    /// Fetch the busy pin state
+    fn get_busy(&mut self) -> Result<PinState, Self::Error> {
+        let v = self.busy.as_ref().unwrap().is_high()?;
+        match v {
+            true => Ok(PinState::High),
+            false => Ok(PinState::Low),
+        }
+    }
+}
+
+impl <'a> Ready for Cp2130Driver<'a> {
+    type Error = Error;
+
+    /// Fetch the ready pin state
+    fn get_ready(&mut self) -> Result<PinState, Self::Error> {
+        let v = self.ready.as_ref().unwrap().is_high()?;
+        match v {
+            true => Ok(PinState::High),
+            false => Ok(PinState::Low),
+        }
+    }
+}
+
+impl <'a> DelayMs<u32> for Cp2130Driver<'a> {
+    fn delay_ms(&mut self, _ms: u32) {
+        unimplemented!();
+    }
+}
+
+
+impl <'a> DelayUs<u32> for Cp2130Driver<'a> {
+    fn delay_us(&mut self, _us: u32) {
+        unimplemented!();
+    }
+}
+
+
+impl <'a> SpiTransfer<u8> for Cp2130Driver<'a>
+{
+    type Error = Error;
+
+    fn transfer<'w>(&mut self, data: &'w mut [u8]) -> Result<&'w [u8], Self::Error> {
+        let r = self.spi.transfer(data)?;
+        Ok(r)
+    }
+}
+impl <'a> SpiWrite<u8> for Cp2130Driver<'a>
+{
+    type Error = Error;
+
+    fn write<'w>(&mut self, data: &[u8]) -> Result<(), Self::Error> {
+        self.spi.write(data)?;
+        Ok(())
+    }
+}
+
+#[cfg(nope)]
+impl <'a> Transactional for Cp2130Driver<'a> {
+    type Error = Error;
+
+    
+}

--- a/src/hal/error.rs
+++ b/src/hal/error.rs
@@ -3,6 +3,7 @@
 #[derive(Debug)]
 pub enum HalError  {
     InvalidConfig,
+    InvalidSpiMode,
     NoPin,
     
     #[cfg(feature = "hal-cp2130")]
@@ -32,6 +33,6 @@ impl From<std::io::Error> for HalError {
 #[cfg(feature = "hal-linux")]
 impl From<linux_embedded_hal::sysfs_gpio::Error> for HalError {
     fn from(e: linux_embedded_hal::sysfs_gpio::Error) -> Self {
-        Self::Pin(e)
+        Self::Sysfs(e)
     }
 }

--- a/src/hal/error.rs
+++ b/src/hal/error.rs
@@ -1,34 +1,39 @@
 
+/// Error type combining SPI and Pin errors for utility
 #[derive(Debug)]
-pub enum Error {
+pub enum HalError  {
     InvalidConfig,
+    NoCsPin,
+    NoResetPin,
+    NoBusyPin,
+    NoReadyPin,
 
     #[cfg(feature = "hal-cp2130")]
     Cp2130(driver_cp2130::Error),
 
     #[cfg(feature = "hal-linux")]
-    Io(std::io::Error),
+    Io(std::io::ErrorKind),
 
     #[cfg(feature = "hal-linux")]
-    Pin(linux_embedded_hal::sysfs_gpio::Error),
+    Sysfs(linux_embedded_hal::sysfs_gpio::Error),
 }
 
 #[cfg(feature = "hal-cp2130")]
-impl From<driver_cp2130::Error> for Error {
+impl From<driver_cp2130::Error> for HalError {
     fn from(e: driver_cp2130::Error) -> Self {
         Self::Cp2130(e)
     }
 }
 
 #[cfg(feature = "hal-linux")]
-impl From<std::io::Error> for Error {
+impl From<std::io::Error> for HalError {
     fn from(e: std::io::Error) -> Self {
-        Self::Io(e)
+        Self::Io(e.kind())
     }
 }
 
 #[cfg(feature = "hal-linux")]
-impl From<linux_embedded_hal::sysfs_gpio::Error> for Error {
+impl From<linux_embedded_hal::sysfs_gpio::Error> for HalError {
     fn from(e: linux_embedded_hal::sysfs_gpio::Error) -> Self {
         Self::Pin(e)
     }

--- a/src/hal/error.rs
+++ b/src/hal/error.rs
@@ -1,0 +1,35 @@
+
+#[derive(Debug)]
+pub enum Error {
+    InvalidConfig,
+
+    #[cfg(feature = "hal-cp2130")]
+    Cp2130(driver_cp2130::Error),
+
+    #[cfg(feature = "hal-linux")]
+    Io(std::io::Error),
+
+    #[cfg(feature = "hal-linux")]
+    Pin(linux_embedded_hal::sysfs_gpio::Error),
+}
+
+#[cfg(feature = "hal-cp2130")]
+impl From<driver_cp2130::Error> for Error {
+    fn from(e: driver_cp2130::Error) -> Self {
+        Self::Cp2130(e)
+    }
+}
+
+#[cfg(feature = "hal-linux")]
+impl From<std::io::Error> for Error {
+    fn from(e: std::io::Error) -> Self {
+        Self::Io(e)
+    }
+}
+
+#[cfg(feature = "hal-linux")]
+impl From<linux_embedded_hal::sysfs_gpio::Error> for Error {
+    fn from(e: linux_embedded_hal::sysfs_gpio::Error) -> Self {
+        Self::Pin(e)
+    }
+}

--- a/src/hal/error.rs
+++ b/src/hal/error.rs
@@ -3,11 +3,8 @@
 #[derive(Debug)]
 pub enum HalError  {
     InvalidConfig,
-    NoCsPin,
-    NoResetPin,
-    NoBusyPin,
-    NoReadyPin,
-
+    NoPin,
+    
     #[cfg(feature = "hal-cp2130")]
     Cp2130(driver_cp2130::Error),
 

--- a/src/hal/linux.rs
+++ b/src/hal/linux.rs
@@ -1,0 +1,45 @@
+
+use std::fs::read_to_string;
+use std::string::{String, ToString};
+
+use serde::{de::DeserializeOwned, Deserialize};
+use structopt::StructOpt
+;
+pub use simplelog::{LevelFilter, TermLogger};
+
+pub use embedded_hal::digital::v2::{InputPin, OutputPin};
+
+use super::{SpiConfig, PinConfig, Error};
+
+extern crate linux_embedded_hal;
+pub use linux_embedded_hal::sysfs_gpio::{Direction, Error as PinError};
+pub use linux_embedded_hal::{spidev, Delay, Pin as Pindev, Spidev, spidev::SpiModeFlags};
+
+pub struct LinuxDevice {
+    spi_dev: Spidev,
+}
+
+impl LinuxDevice {
+    /// Load an SPI device using the provided configuration
+    pub fn new(path: &str, spi: &SpiConfig, pin: &PinConfig) -> Result<Spidev, Error> {
+        debug!(
+            "Conecting to spi: {} at {} baud with mode: {:?}",
+            path, baud, mode
+        );
+
+        let mut spi_dev = Spidev::open(path).expect("error opening spi device");
+
+        let mut config = spidev::SpidevOptions::new();
+        config.mode(SpiModeFlags::SPI_MODE_0 | SpiModeFlags::SPI_NO_CS);
+        config.max_speed_hz(baud);
+        spi_dev.configure(&config)
+            .expect("error configuring spi device");
+
+        Ok(Self{
+            spi_dev,
+        })
+    }
+}
+
+
+

--- a/src/hal/linux.rs
+++ b/src/hal/linux.rs
@@ -1,7 +1,7 @@
 
 extern crate linux_embedded_hal;
 pub use linux_embedded_hal::sysfs_gpio::{Direction, Error as PinError};
-pub use linux_embedded_hal::{spidev, Delay, Pin as Pindev, Spidev, spidev::SpiModeFlags};
+pub use linux_embedded_hal::{spidev, Delay, SysfsPin as Pindev, Spidev, spidev::SpiModeFlags};
 
 use super::*;
 

--- a/src/hal/linux.rs
+++ b/src/hal/linux.rs
@@ -9,7 +9,7 @@ pub use simplelog::{LevelFilter, TermLogger};
 
 pub use embedded_hal::digital::v2::{InputPin, OutputPin};
 
-use super::{SpiConfig, PinConfig, Error};
+use super::{HalError, HalPins, SpiConfig, PinConfig, Error};
 
 extern crate linux_embedded_hal;
 pub use linux_embedded_hal::sysfs_gpio::{Direction, Error as PinError};
@@ -21,25 +21,76 @@ pub struct LinuxDevice {
 
 impl LinuxDevice {
     /// Load an SPI device using the provided configuration
-    pub fn new(path: &str, spi: &SpiConfig, pin: &PinConfig) -> Result<Spidev, Error> {
+    pub fn new(path: &str, spi: &SpiConfig) -> Result<Self, HalError> {
         debug!(
             "Conecting to spi: {} at {} baud with mode: {:?}",
             path, baud, mode
         );
 
-        let mut spi_dev = Spidev::open(path).expect("error opening spi device");
-
-        let mut config = spidev::SpidevOptions::new();
-        config.mode(SpiModeFlags::SPI_MODE_0 | SpiModeFlags::SPI_NO_CS);
-        config.max_speed_hz(baud);
-        spi_dev.configure(&config)
-            .expect("error configuring spi device");
+        let mut spi_dev = load_spi(path, spi.baud, spi.mode)?;
 
         Ok(Self{
             spi_dev,
         })
     }
+
+    pub fn load_pins(&mut self, pin: &PinConfig) -> Result<HalPins<Pindev, Pindev>, HalError> {
+        let chip_select = load_pin(pins.chip_select as u8, Direction::Out)?;
+
+        let reset = load_pin(pins.reset as u8, Direction::Out)?;
+
+        let busy = match pins.busy {
+            Some(p) => Some(load_pin(p, Direction::In)?),
+            None => None,
+        };
+
+        let ready = match pins.ready {
+            Some(p) => Some(load_pin(p, Direction::In)?),
+            None => None,
+        };
+
+        let pins = HalPins{
+            cs: Cp2130OutputPin(chip_select),
+            reset: Cp2130OutputPin(reset),
+            busy: MaybeGpio( busy.map(|p| Cp2130InputPin(p)) ),
+            ready: MaybeGpio( ready.map(|p| Cp2130InputPin(p)) ),
+        };
+        
+        Ok(pins)
+    }
 }
 
 
 
+/// Load an SPI device using the provided configuration
+fn load_spi(path: &str, baud: u32, mode: spidev::SpiModeFlags) -> Result<Spidev, HalError> {
+    debug!(
+        "Conecting to spi: {} at {} baud with mode: {:?}",
+        path, baud, mode
+    );
+
+    let mut spi = Spidev::open(path).expect("error opening spi device");
+
+    let mut config = spidev::SpidevOptions::new();
+    config.mode(SpiModeFlags::SPI_MODE_0 | SpiModeFlags::SPI_NO_CS);
+    config.max_speed_hz(baud);
+    spi.configure(&config)
+        .expect("error configuring spi device");
+
+    spi
+}
+
+/// Load a Pin using the provided configuration
+fn load_pin(index: u64, direction: Direction) -> Result<Pindev, HalError> {
+    debug!(
+        "Connecting to pin: {} with direction: {:?}",
+        index, direction
+    );
+
+    let p = Pindev::new(index);
+    p.export().expect("error exporting cs pin");
+    p.set_direction(direction)
+        .expect("error setting cs pin direction");
+
+    p
+}

--- a/src/hal/mod.rs
+++ b/src/hal/mod.rs
@@ -82,13 +82,13 @@ pub fn load_hal(config: &DeviceConfig) -> Result<Box<dyn Hal<HalError>>, HalErro
             return Err(HalError::InvalidConfig)
         },
         (Some(s), None) => {
-            
+            unimplemented!()
         },
         (None, Some(i)) => {
-            let d = cp2130::Cp2130Driver::new(*i, &config.spi, &config.pins)?;
-            return Ok(Box::new(d))
-            //let w: Wrapper = Wrapper::new(d, d.chip_select.take().unwrap());
-            //return Ok(Box::new(w))
+            let mut d = cp2130::Cp2130Driver::new(*i, &config.spi, &config.pins)?;
+            let cs = d.chip_select.take().unwrap();
+            let w = Wrapper::new(d, cs);
+            return Ok(Box::new(w))
         },
         _ => {
             error!("No SPI configuration provided");

--- a/src/hal/mod.rs
+++ b/src/hal/mod.rs
@@ -1,0 +1,99 @@
+
+use std::string::{String, ToString};
+use std::boxed::Box;
+
+use serde::{Deserialize};
+use structopt::StructOpt;
+
+pub mod error;
+pub use error::Error;
+
+#[cfg(feature = "hal-linux")]
+pub mod linux;
+
+#[cfg(feature = "hal-cp2130")]
+pub mod cp2130;
+
+
+use crate::*;
+
+
+/// Generic device configuration structure for SPI drivers
+#[derive(Debug, StructOpt, Deserialize)]
+pub struct DeviceConfig {
+    /// Linux SpiDev SPI device
+    #[structopt(long, group = "spi-kind", env = "SPI_DEV")]
+    spi_dev: Option<String>,
+
+    /// CP2130 SPI device
+    #[structopt(long, group = "spi-kind", env = "CP2130_DEV")]
+    cp2130_dev: Option<usize>,
+
+    #[structopt(flatten)]
+    #[serde(flatten)]
+    spi: SpiConfig,
+
+    #[structopt(flatten)]
+    #[serde(flatten)]
+    pins: PinConfig,
+}
+
+/// SPI device configuration
+#[derive(Debug, Clone, StructOpt, Deserialize)]
+pub struct SpiConfig {
+    /// Baud rate setting
+    #[structopt(long = "spi-baud",
+        default_value = "1000000",
+        env = "SPI_BAUD"
+    )]
+    baud: u32,
+
+    /// SPI mode setting
+    #[structopt(long = "spi-mode", default_value="0", env="SPI_MODE")]
+    mode: u32,
+}
+
+/// Pin configuration object
+#[derive(Debug, Clone, StructOpt, Deserialize)]
+pub struct PinConfig {
+    /// Chip Select (output) pin
+    #[structopt(long = "cs-pin", default_value = "16", env = "CS_PIN")]
+    chip_select: u64,
+
+    /// Reset (output) pin
+    #[structopt(long = "reset-pin", default_value = "17", env = "RESET_PIN")]
+    reset: u64,
+
+    /// Busy (input) pin
+    #[structopt(long = "busy-pin", env = "BUSY_PIN")]
+    busy: Option<u64>,
+
+    /// Ready (input) pin
+    #[structopt(long = "ready-pin", env = "READY_PIN")]
+    ready: Option<u64>,
+}
+
+/// Load a hal instance from the provided configuration
+pub fn load_hal(config: &DeviceConfig) -> Result<Box<dyn Hal<Error, Error>>, Error> {
+
+    match (&config.spi_dev, &config.cp2130_dev) {
+        (Some(_), Some(_)) => {
+            error!("Only one of spi_dev and cp2130_dev may be specified");
+            return Err(Error::InvalidConfig)
+        },
+        (Some(s), None) => {
+            
+        },
+        (None, Some(i)) => {
+            let d = cp2130::Cp2130Driver::new(*i, &config.spi, &config.pins)?;
+            //return Ok(Box::new(d))
+        },
+        (_) => {
+            error!("No SPI configuration provided");
+            return Err(Error::InvalidConfig)
+        }
+    }
+
+
+    unimplemented!()
+}

--- a/src/hal/mod.rs
+++ b/src/hal/mod.rs
@@ -110,10 +110,45 @@ pub struct HalPins<OutputPin, InputPin> where
     OutputPin: digital::OutputPin,
     InputPin: digital::InputPin,
 {
-   cs: OutputPin,
-   reset: OutputPin,
-   busy: MaybeGpio<InputPin>,
-   ready: MaybeGpio<InputPin>, 
+   cs: HalPin<OutputPin>,
+   reset: HalPin<OutputPin>,
+   busy: MaybeGpio<HalPin<InputPin>>,
+   ready: MaybeGpio<HalPin<InputPin>>, 
+}
+
+
+/// HalPin object automatically wraps pin objects with errors that
+/// can be coerced to HalError
+pub struct HalPin<T> (T);
+
+impl <'a, T, E> digital::OutputPin for HalPin<T> where
+    T: digital::OutputPin<Error = E>,
+    E: Into<HalError>,
+{
+    type Error = HalError;
+
+    fn set_high(&mut self) -> Result<(), Self::Error> {
+        self.0.set_high().map_err(|e| e.into())
+    }
+
+    fn set_low(&mut self) -> Result<(), Self::Error> {
+        self.0.set_low().map_err(|e| e.into())
+    }
+}
+
+impl <'a, T, E> digital::InputPin for HalPin<T> where
+    T: digital::InputPin<Error = E>,
+    E: Into<HalError>,
+{
+    type Error = HalError;
+
+    fn is_high(&self) -> Result<bool, Self::Error> {
+        self.0.is_high().map_err(|e| e.into())
+    }
+
+    fn is_low(&self) -> Result<bool, Self::Error> {
+        self.0.is_low().map_err(|e| e.into())
+    }
 }
 
 /// MaybeGpio wraps a GPIO option to allow for unconfigured pins

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,7 @@ pub trait Hal<E>:
     PrefixWrite<Error=E> +
     PrefixRead<Error=E> +
 
-    spi::Write<u8, Error=E> + 
+    spi::Write<u8, Error=E> +
     spi::Transfer<u8, Error=E> + 
     
     Busy<Error=E> + 
@@ -76,7 +76,7 @@ impl <T, E> Hal<E> for T where T:
     PrefixWrite<Error=E> +
     PrefixRead<Error=E> +
 
-    spi::Write<u8, Error=E> + 
+    spi::Write<u8, Error=E> +
     spi::Transfer<u8, Error=E> + 
     
     Busy<Error=E> + 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@ pub trait Transactional {
     fn spi_write(&mut self, prefix: &[u8], data: &[u8]) -> Result<(), Self::Error>;
 }
 
-pub type Transaction<'a> = embedded_hal::blocking::spi::Operation<'a>;
+pub type Transaction<'a> = embedded_hal::blocking::spi::Operation<'a, u8>;
 
 /// Busy trait for peripherals that support a busy signal
 pub trait Busy {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,26 +54,9 @@ pub trait Transactional {
 
     /// Write writes the prefix buffer then writes the output buffer
     fn spi_write(&mut self, prefix: &[u8], data: &[u8]) -> Result<(), Self::Error>;
-
-    /// Transfer writes the outgoing buffer while reading into the incoming buffer
-    /// note that outgoing and incoming must have the same length
-    //fn transfer(&mut self, outgoing: &[u8], incoming: &mut [u8]) -> Result<(), Self::Error>;
-
-    /// Exec allows 'Transaction' objects to be chained together into a single transaction
-    fn spi_exec(&mut self, transactions: &mut [Transaction]) -> Result<(), Self::Error>;
 }
 
-/// Transaction enum defines possible SPI transactions
-#[derive(Debug, PartialEq)]
-pub enum Transaction<'a> {
-    // Write the supplied buffer to the peripheral
-    Write(&'a [u8]),
-    // Read from the peripheral into the supplied buffer
-    Read(&'a mut [u8]),
-    // Write the first buffer while reading into the second
-    // This behaviour is actually just the same as Read
-    //Transfer((&'a [u8], &'a mut [u8]))
-}
+pub type Transaction<'a> = embedded_hal::blocking::spi::Operation<'a>;
 
 /// Busy trait for peripherals that support a busy signal
 pub trait Busy {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,7 +183,7 @@ where
     fn spi_read<'a>(&mut self, prefix: &[u8], data: &'a mut [u8]) -> Result<(), Self::Error> {
         let mut ops = [
             spi::Operation::Write(prefix),
-            spi::Operation::WriteRead(data),
+            spi::Operation::Transfer(data),
         ];
 
         self.exec(&mut ops)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 //! the `compat` feature, and a basic mocking adaptor enabled with the `mock` feature.
 
 
-#![cfg_attr(not(feature = "utils"), no_std)]
+#![cfg_attr(not(feature = "hal"), no_std)]
 
 #[macro_use]
 extern crate log;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,9 +139,10 @@ pub trait Ready {
 
 /// Error type combining SPI and Pin errors for utility
 #[derive(Debug, Clone, PartialEq)]
-pub enum Error<SpiError, PinError> {
+pub enum Error<SpiError, PinError, DelayError> {
     Spi(SpiError),
     Pin(PinError),
+    Delay(DelayError),
     Aborted,
 }
 
@@ -166,7 +167,7 @@ where
             spi::Operation::Write(data),
         ];
 
-        self.exec(&mut ops)?;
+        self.try_exec(&mut ops)?;
         
         Ok(())
     }
@@ -186,7 +187,7 @@ where
             spi::Operation::Transfer(data),
         ];
 
-        self.exec(&mut ops)?;
+        self.try_exec(&mut ops)?;
         
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,11 +37,25 @@ extern crate toml;
 #[cfg(feature = "utils")]
 extern crate simplelog;
 
-#[cfg(feature = "utils")]
+#[cfg(feature = "hal-linux")]
 extern crate linux_embedded_hal;
+
+#[cfg(feature = "hal-cp2130")]
+extern crate driver_cp2130;
 
 #[cfg(feature = "utils")]
 pub mod utils;
+
+pub mod hal;
+
+use embedded_hal::blocking::delay::{DelayMs, DelayUs};
+use embedded_hal::blocking::spi::{Write as SpiWrite, Transfer as SpiTransfer, Transactional as SpiTransactional};
+
+/// CSManaged marker trait indicates CS is managed by the drivert
+pub trait CSManaged {}
+
+/// HAL trait abstracts required functions for SPI peripherals
+pub trait Hal<SpiError, PinError>: Transactional<Error=SpiError> + Busy<Error=PinError> + Ready<Error=PinError> + Reset<Error=PinError> + DelayMs<u32> + DelayUs<u32> {}
 
 /// Transaction trait provides higher level, transaction-based, SPI constructs
 /// These are executed in a single SPI transaction (without de-asserting CS).
@@ -70,9 +84,6 @@ pub enum Transaction<'a> {
     Write(&'a [u8]),
     // Read from the peripheral into the supplied buffer
     Read(&'a mut [u8]),
-    // Write the first buffer while reading into the second
-    // This behaviour is actually just the same as Read
-    //Transfer((&'a [u8], &'a mut [u8]))
 }
 
 /// Busy trait for peripherals that support a busy signal
@@ -113,3 +124,4 @@ pub enum PinState {
     Low,
     High,
 }
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,13 +26,13 @@ extern crate libc;
 #[cfg(feature = "ffi")]
 pub mod ffi;
 
-#[cfg(feature = "utils")]
+#[cfg(feature = "serde")]
 extern crate serde;
 
-#[cfg(feature = "utils")]
+#[cfg(feature = "toml")]
 extern crate toml;
 
-#[cfg(feature = "utils")]
+#[cfg(feature = "simplelog")]
 extern crate simplelog;
 
 #[cfg(feature = "hal-linux")]
@@ -41,11 +41,9 @@ extern crate linux_embedded_hal;
 #[cfg(feature = "hal-cp2130")]
 extern crate driver_cp2130;
 
-
-#[cfg(feature = "utils")]
-pub mod utils;
-
+#[cfg(feature = "hal")]
 pub mod hal;
+
 
 pub mod wrapper;
 
@@ -62,7 +60,7 @@ pub trait Hal<E>:
     PrefixRead<Error=E> +
 
     spi::Write<u8, Error=E> +
-    spi::Transfer<u8, Error=E> + 
+    spi::Transfer<u8, Error=E> +
     
     Busy<Error=E> + 
     Ready<Error=E> + 
@@ -85,7 +83,6 @@ impl <T, E> Hal<E> for T where T:
     
     DelayMs<u32> + 
     DelayUs<u32> {}
-
 
 /// PrefixRead trait provides a higher level, write then read function
 pub trait PrefixRead {

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -137,8 +137,8 @@ pub enum MockExec {
     SpiTransfer(Vec<u8>, Vec<u8>),
 }
 
-impl<'a> From<&spi::Operation<'a>> for MockExec {
-    fn from(t: &spi::Operation<'a>) -> Self {
+impl<'a> From<&spi::Operation<'a, u8>> for MockExec {
+    fn from(t: &spi::Operation<'a, u8>) -> Self {
         match t {
             spi::Operation::Write(ref d) => {
                 MockExec::SpiWrite(d.to_vec())
@@ -389,12 +389,12 @@ impl spi::Write<u8> for Spi {
     }
 }
 
-impl spi::Transactional for Spi {
+impl spi::Transactional<u8> for Spi {
     type Error = Error<(), ()>;
 
     fn exec<'a, O>(&mut self, mut operations: O) -> Result<(), Self::Error>
     where
-        O: AsMut<[spi::Operation<'a>]> 
+        O: AsMut<[spi::Operation<'a, u8>]> 
     {
         let mut i = self.inner.lock().unwrap();
         let index = i.index;

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -143,7 +143,7 @@ impl<'a> From<&spi::Operation<'a, u8>> for MockExec {
             spi::Operation::Write(ref d) => {
                 MockExec::SpiWrite(d.to_vec())
             }
-            spi::Operation::WriteRead(ref d) => {
+            spi::Operation::Transfer(ref d) => {
                 MockExec::SpiTransfer(d.to_vec(), vec![0u8; d.len()])
             }
         }

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -365,7 +365,7 @@ impl spi::Transactional<u8> for Spi {
                 let x = e.get(i);
 
                 match (t, x) {
-                    (spi::Operation::WriteRead(ref mut t_in), Some(MockExec::SpiTransfer(_x_out, x_in))) => {
+                    (spi::Operation::Transfer(ref mut t_in), Some(MockExec::SpiTransfer(_x_out, x_in))) => {
                         t_in.copy_from_slice(&x_in)
                     },
                     (spi::Operation::Write(ref _t_out), Some(MockExec::SpiWrite(ref _x_out))) => {

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -41,8 +41,10 @@ pub struct Delay {
 #[derive(Clone, Debug, PartialEq)]
 pub enum MockTransaction {
     None,
+
     SpiWrite(Id, Vec<u8>, Vec<u8>),
     SpiRead(Id, Vec<u8>, Vec<u8>),
+
     SpiExec(Id, Vec<MockExec>),
 
     Busy(Id, PinState),
@@ -132,21 +134,17 @@ impl MockTransaction {
 #[derive(Clone, Debug, PartialEq)]
 pub enum MockExec {
     SpiWrite(Vec<u8>),
-    SpiRead(Vec<u8>),
+    SpiTransfer(Vec<u8>, Vec<u8>),
 }
 
-impl<'a> From<&Transaction<'a>> for MockExec {
-    fn from(t: &Transaction<'a>) -> Self {
+impl<'a> From<&spi::Operation<'a>> for MockExec {
+    fn from(t: &spi::Operation<'a>) -> Self {
         match t {
-            Transaction::Read(ref d) => {
-                let mut v = Vec::with_capacity(d.len());
-                v.copy_from_slice(d);
-                MockExec::SpiRead(v)
+            spi::Operation::Write(ref d) => {
+                MockExec::SpiWrite(d.to_vec())
             }
-            Transaction::Write(ref d) => {
-                let mut v = Vec::with_capacity(d.len());
-                v.copy_from_slice(d);
-                MockExec::SpiWrite(v)
+            spi::Operation::WriteRead(ref o, ref i) => {
+                MockExec::SpiTransfer(o.to_vec(), i.to_vec())
             }
         }
     }
@@ -276,39 +274,6 @@ impl Transactional for Spi {
 
         Ok(())
     }
-
-    /// Execute the provided transactions
-    fn spi_exec(&mut self, transactions: &mut [Transaction]) -> Result<(), Self::Error> {
-        let mut i = self.inner.lock().unwrap();
-        let index = i.index;
-
-        // Save actual calls
-        let t: Vec<MockExec> = transactions
-            .iter()
-            .map(|ref v| MockExec::from(*v))
-            .collect();
-        i.actual.push(MockTransaction::SpiExec(self.id, t));
-
-        // Load expected reads
-        if let MockTransaction::SpiExec(_id, e) = &i.expected[index] {
-            for i in 0..transactions.len() {
-                let t = &mut transactions[i];
-                let x = e.get(i);
-
-                match (t, x) {
-                    (Transaction::Read(ref mut v), Some(MockExec::SpiRead(d))) => {
-                        v.copy_from_slice(&d)
-                    }
-                    _ => (),
-                }
-            }
-        }
-
-        // Update expectation index
-        i.index += 1;
-
-        Ok(())
-    }
 }
 
 impl Busy for Spi {
@@ -416,6 +381,51 @@ impl spi::Write<u8> for Spi {
 
         // Save actual call
         i.actual.push(MockTransaction::Write(self.id, data.into()));
+
+        // Update expectation index
+        i.index += 1;
+
+        Ok(())
+    }
+}
+
+impl spi::Transactional for Spi {
+    type Error = Error<(), ()>;
+
+    fn exec<'a, O>(&mut self, mut operations: O) -> Result<(), Self::Error>
+    where
+        O: AsMut<[spi::Operation<'a>]> 
+    {
+        let mut i = self.inner.lock().unwrap();
+        let index = i.index;
+
+        // Save actual calls
+        let t: Vec<MockExec> = operations
+            .as_mut()
+            .iter()
+            .map(|ref v| MockExec::from(*v))
+            .collect();
+        i.actual.push(MockTransaction::SpiExec(self.id, t));
+
+        let transactions = operations.as_mut();
+
+        // Load expected reads
+        if let MockTransaction::SpiExec(_id, e) = &i.expected[index] {
+            for i in 0..transactions.len() {
+                let t = &mut transactions[i];
+                let x = e.get(i);
+
+                match (t, x) {
+                    (Transaction::WriteRead(ref t_out, ref mut t_in), Some(MockExec::SpiTransfer(x_out, x_in))) => {
+                        t_in.copy_from_slice(&x_in)
+                    },
+                    (Transaction::Write(ref t_out), Some(MockExec::SpiWrite(ref x_out))) => {
+                        //assert_eq!(t_out, x_out);
+                    },
+                    _ => (),
+                }
+            }
+        }
 
         // Update expectation index
         i.index += 1;

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -344,10 +344,7 @@ impl spi::Write<u8> for Spi {
 impl spi::Transactional<u8> for Spi {
     type Error = Error<(), ()>;
 
-    fn exec<'a, O>(&mut self, mut operations: O) -> Result<(), Self::Error>
-    where
-        O: AsMut<[spi::Operation<'a, u8>]> 
-    {
+    fn exec<'a>(&mut self, operations: &mut [spi::Operation<'a, u8>]) -> Result<(), Self::Error> {
         let mut i = self.inner.lock().unwrap();
         let index = i.index;
 
@@ -473,6 +470,7 @@ mod test {
     use std::*;
     use std::{panic, vec};
 
+    use crate::{PrefixRead, PrefixWrite};
     use super::*;
 
     #[test]

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -416,10 +416,10 @@ impl spi::Transactional for Spi {
                 let x = e.get(i);
 
                 match (t, x) {
-                    (Transaction::WriteRead(ref t_out, ref mut t_in), Some(MockExec::SpiTransfer(x_out, x_in))) => {
+                    (Transaction::WriteRead(ref _t_out, ref mut t_in), Some(MockExec::SpiTransfer(_x_out, x_in))) => {
                         t_in.copy_from_slice(&x_in)
                     },
-                    (Transaction::Write(ref t_out), Some(MockExec::SpiWrite(ref x_out))) => {
+                    (Transaction::Write(ref _t_out), Some(MockExec::SpiWrite(ref _x_out))) => {
                         //assert_eq!(t_out, x_out);
                     },
                     _ => (),

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -6,19 +6,19 @@ use embedded_hal::blocking::spi::{self, Transfer, Write, Operation};
 use embedded_hal::digital::v2::{OutputPin};
 use embedded_hal::blocking::delay::{DelayMs, DelayUs};
 
-use crate::{Busy, Error, PinState, Ready, Reset, ManagedChipSelect};
+use crate::{Busy, PinState, Ready, Reset, ManagedChipSelect};
 
 /// Wrapper provides a wrapper around an SPI object with Chip Select management
-pub struct Wrapper<Inner, SpiError, Cs, PinError> {
+pub struct Wrapper<Inner, Cs, E> {
     inner: Inner,
     cs: Cs,
 
-    _e: std::marker::PhantomData<Error<SpiError, PinError>>,
+    _e: std::marker::PhantomData<E>,
 }
 
-impl <Inner, SpiError, Cs, PinError> ManagedChipSelect for Wrapper<Inner, SpiError, Cs, PinError> {}
+impl <Inner, Cs, E> ManagedChipSelect for Wrapper<Inner, Cs, E> {}
 
-impl <Inner, SpiError, Cs, PinError> Wrapper<Inner, SpiError, Cs, PinError>  {
+impl <Inner, Cs, E> Wrapper<Inner, Cs, E>  {
 
     /// Create a new wrapper with the provided chip select pin
     pub fn new(inner: Inner, cs: Cs) -> Self {
@@ -35,7 +35,7 @@ impl <Inner, SpiError, Cs, PinError> Wrapper<Inner, SpiError, Cs, PinError>  {
 
 /// Derefs to allow accessing methods on inner
 #[cfg(feature="deref")]
-impl <Inner, SpiError, Cs, PinError> core::ops::Deref for Wrapper<Inner, SpiError, Cs, PinError> {
+impl <Inner, SpiError, Cs, PinError> core::ops::Deref for Wrapper<Inner, Cs, E> {
     type Target = Inner;
 
     fn deref(&self) -> &Self::Target {
@@ -44,114 +44,123 @@ impl <Inner, SpiError, Cs, PinError> core::ops::Deref for Wrapper<Inner, SpiErro
 }
 
 #[cfg(feature="deref")]
-impl <Inner, SpiError, Cs, PinError> core::ops::DerefMut for Wrapper<Inner, SpiError, Cs, PinError> {
+impl <Inner, SpiError, Cs, PinError> core::ops::DerefMut for Wrapper<Inner, Cs, E> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
      } 
 }
 
 
-impl <Inner, SpiError, Cs, PinError> spi::Transfer<u8> for Wrapper<Inner, SpiError, Cs, PinError> 
+impl <Inner, Cs, E, SpiError, PinError> spi::Transfer<u8> for Wrapper<Inner, Cs, E> 
 where 
     Inner: Transfer<u8, Error=SpiError>,
-    Cs: OutputPin<Error=PinError>
+    Cs: OutputPin<Error=PinError>,
+    SpiError: Into<E>,
+    PinError: Into<E>,
 {
-    type Error = Error<SpiError, PinError>;
+    type Error = E;
 
     fn transfer<'w>(&mut self, data: &'w mut [u8]) -> Result<&'w [u8], Self::Error> {
-        self.cs.set_low().map_err(Error::Pin)?;
+        self.cs.set_low().map_err(PinError::into)?;
         
-        let r = self.inner.transfer(data).map_err(Error::Spi);
+        let r = self.inner.transfer(data).map_err(SpiError::into);
 
-        self.cs.set_high().map_err(Error::Pin)?;
+        self.cs.set_high().map_err(PinError::into)?;
 
         r
     }
 }
 
 /// `spi::Write` implementation managing the CS pin
-impl <Inner, SpiError, Cs, PinError> spi::Write<u8> for Wrapper<Inner, SpiError, Cs, PinError> 
+impl <Inner, Cs, E, SpiError, PinError> spi::Write<u8> for Wrapper<Inner, Cs, E> 
 where 
     Inner: Write<u8, Error=SpiError>,
-    Cs: OutputPin<Error=PinError>
+    Cs: OutputPin<Error=PinError>,
+    SpiError: Into<E>,
+    PinError: Into<E>,
 {
-    type Error = Error<SpiError, PinError>;
+    type Error = E;
 
     fn write<'w>(&mut self, data: &'w [u8]) -> Result<(), Self::Error> {
-        self.cs.set_low().map_err(Error::Pin)?;
+        self.cs.set_low().map_err(PinError::into)?;
         
-        let r = self.inner.write(data).map_err(Error::Spi);
+        let r = self.inner.write(data).map_err(SpiError::into);
 
-        self.cs.set_high().map_err(Error::Pin)?;
+        self.cs.set_high().map_err(PinError::into)?;
 
         r
     }
 }
 
 /// `spi::Transactional` implementation managing CS pin
-impl<Inner, SpiError, Cs, PinError> spi::Transactional<u8> for Wrapper<Inner, SpiError, Cs, PinError>
+impl <Inner, Cs, E, SpiError, PinError> spi::Transactional<u8> for Wrapper<Inner, Cs, E>
 where
     Inner: spi::Transactional<u8, Error = SpiError>,
-    Cs: OutputPin<Error=PinError>
+    Cs: OutputPin<Error=PinError>,
+    SpiError: Into<E>,
+    PinError: Into<E>,
 {
-    type Error = Error<SpiError, PinError>;
+    type Error = E;
 
     fn exec<'a, O>(&mut self, operations: O) -> Result<(), Self::Error>
     where
         O: AsMut<[Operation<'a, u8>]> 
     {
-        self.cs.set_low().map_err(Error::Pin)?;
+        self.cs.set_low().map_err(PinError::into)?;
 
-        let r = spi::Transactional::exec(&mut self.inner, operations).map_err(Error::Spi);
+        let r = spi::Transactional::exec(&mut self.inner, operations).map_err(SpiError::into);
 
-        self.cs.set_high().map_err(Error::Pin)?;
+        self.cs.set_high().map_err(PinError::into)?;
 
         r
     }
 }
 
 /// Reset pin implementation for inner objects implementing `Reset`
-impl <Inner, SpiError, Cs, PinError> Reset for Wrapper<Inner, SpiError, Cs, PinError>  
+impl <Inner, Cs, E, PinError> Reset for Wrapper<Inner, Cs, E>  
 where
     Inner: Reset<Error=PinError>,
+    PinError: Into<E>,
 {
-    type Error = Error<SpiError, PinError>;
+    type Error = E;
 
     /// Set the reset pin state
     fn set_reset(&mut self, state: PinState) -> Result<(), Self::Error> {
-        Reset::set_reset(&mut self.inner, state).map_err(Error::Pin)
+        Reset::set_reset(&mut self.inner, state).map_err(PinError::into)
     }
 }
 
 /// Busy pin implementation for inner objects implementing `Busy`
-impl <Inner, SpiError, Cs, PinError> Busy for Wrapper<Inner, SpiError, Cs, PinError>
+impl <Inner, Cs, E, PinError> Busy for Wrapper<Inner, Cs, E>
 where
     Inner: Busy<Error=PinError>,
+    PinError: Into<E>,
 {
-    type Error = Error<SpiError, PinError>;
+    type Error = E;
 
     /// Fetch the busy pin state
     fn get_busy(&mut self) -> Result<PinState, Self::Error> {
-        Busy::get_busy(&mut self.inner).map_err(Error::Pin)
+        Busy::get_busy(&mut self.inner).map_err(PinError::into)
     }
 }
 
 /// Ready pin implementation for inner object implementing `Ready`
-impl <Inner, SpiError, Cs, PinError> Ready for Wrapper<Inner, SpiError, Cs, PinError> 
+impl <Inner, Cs, E, PinError> Ready for Wrapper<Inner, Cs, E> 
 where
     Inner: Ready<Error=PinError>,
+    PinError: Into<E>,
 {
-    type Error = Error<SpiError, PinError>;
+    type Error = E;
 
     /// Fetch the ready pin state
     fn get_ready(&mut self) -> Result<PinState, Self::Error> {
-        Ready::get_ready(&mut self.inner).map_err(Error::Pin)
+        Ready::get_ready(&mut self.inner).map_err(PinError::into)
     }
 }
 
-impl <Inner, SpiError, Cs, PinError> DelayMs<u32> for Wrapper<Inner, SpiError, Cs, PinError> 
+impl <Inner, Cs, E> DelayMs<u32> for Wrapper<Inner, Cs, E> 
 where
-    Inner: Ready<Error=PinError>,
+    Inner: DelayMs<u32>,
 {
     fn delay_ms(&mut self, _ms: u32) {
         unimplemented!();
@@ -159,9 +168,9 @@ where
 }
 
 
-impl <Inner, SpiError, Cs, PinError> DelayUs<u32> for Wrapper<Inner, SpiError, Cs, PinError> 
+impl <Inner, Cs, E> DelayUs<u32> for Wrapper<Inner, Cs, E> 
 where
-    Inner: Ready<Error=PinError>,
+    Inner: DelayUs<u32>,
 {
     fn delay_us(&mut self, _us: u32) {
         unimplemented!();

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -35,7 +35,7 @@ pub struct Wrapper<Spi, SpiError, CsPin, BusyPin, ReadyPin, ResetPin, PinError, 
 impl<Spi, SpiError, CsPin, BusyPin, ReadyPin, ResetPin, PinError, Delay>
     Wrapper<Spi, SpiError, CsPin, BusyPin, ReadyPin, ResetPin, PinError, Delay>
 where
-    Spi: Transfer<u8, Error = SpiError> + Write<u8, Error = SpiError> + spi::Transactional<Error = SpiError>,
+    Spi: Transfer<u8, Error = SpiError> + Write<u8, Error = SpiError> + spi::Transactional<u8, Error = SpiError>,
     CsPin: OutputPin<Error = PinError>,
     Delay: DelayMs<u32>,
 {
@@ -262,16 +262,16 @@ where
     }
 }
 
-impl<Spi, SpiError, CsPin, BusyPin, ReadyPin, ResetPin, PinError, Delay> spi::Transactional
+impl<Spi, SpiError, CsPin, BusyPin, ReadyPin, ResetPin, PinError, Delay> spi::Transactional<u8>
     for Wrapper<Spi, SpiError, CsPin, BusyPin, ReadyPin, ResetPin, PinError, Delay>
 where
-    Spi: spi::Transactional<Error = SpiError>,
+    Spi: spi::Transactional<u8, Error = SpiError>,
 {
     type Error = SpiError;
 
     fn exec<'a, O>(&mut self, operations: O) -> Result<(), Self::Error>
     where
-        O: AsMut<[Operation<'a>]> 
+        O: AsMut<[Operation<'a, u8>]> 
     {
         spi::Transactional::exec(&mut self.spi, operations)
     }

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -3,7 +3,7 @@
 //! and `embedded_hal::digital::v2::OutputPin` to provide a transactional API for SPI transactions.
 
 use embedded_hal::blocking::delay::DelayMs;
-use embedded_hal::blocking::spi::{self, Transfer, Write, Operation, Transactional as _};
+use embedded_hal::blocking::spi::{self, Transfer, Write, Operation};
 use embedded_hal::digital::v2::{InputPin, OutputPin};
 
 use crate::{Busy, Error, PinState, Ready, Reset, Transactional};
@@ -114,7 +114,7 @@ where
 impl<Spi, SpiError, CsPin, BusyPin, ReadyPin, ResetPin, PinError, Delay> Transactional
     for Wrapper<Spi, SpiError, CsPin, BusyPin, ReadyPin, ResetPin, PinError, Delay>
 where
-    Spi: Transfer<u8, Error = SpiError> + Write<u8, Error = SpiError> + spi::Transactional<Error = SpiError>,
+    Spi: Transfer<u8, Error = SpiError> + Write<u8, Error = SpiError>,
     CsPin: OutputPin<Error = PinError>,
     Delay: DelayMs<u32>,
 {
@@ -236,7 +236,7 @@ where
 impl<Spi, SpiError, CsPin, BusyPin, ReadyPin, ResetPin, PinError, Delay> Transfer<u8>
     for Wrapper<Spi, SpiError, CsPin, BusyPin, ReadyPin, ResetPin, PinError, Delay>
 where
-    Spi: Transfer<u8, Error = SpiError> + Write<u8, Error = SpiError> + spi::Transactional<Error = SpiError>,
+    Spi: Transfer<u8, Error = SpiError>,
 {
     type Error = SpiError;
 
@@ -252,7 +252,7 @@ where
 impl<Spi, SpiError, CsPin, BusyPin, ReadyPin, ResetPin, PinError, Delay> Write<u8>
     for Wrapper<Spi, SpiError, CsPin, BusyPin, ReadyPin, ResetPin, PinError, Delay>
 where
-    Spi: Transfer<u8, Error = SpiError> + Write<u8, Error = SpiError> + spi::Transactional<Error = SpiError>,
+    Spi: Write<u8, Error = SpiError>,
 {
     type Error = SpiError;
 
@@ -265,11 +265,11 @@ where
 impl<Spi, SpiError, CsPin, BusyPin, ReadyPin, ResetPin, PinError, Delay> spi::Transactional
     for Wrapper<Spi, SpiError, CsPin, BusyPin, ReadyPin, ResetPin, PinError, Delay>
 where
-    Spi: Transfer<u8, Error = SpiError> + Write<u8, Error = SpiError> + spi::Transactional<Error = SpiError>,
+    Spi: spi::Transactional<Error = SpiError>,
 {
     type Error = SpiError;
 
-    fn exec<'a, O>(&mut self, mut operations: O) -> Result<(), Self::Error>
+    fn exec<'a, O>(&mut self, operations: O) -> Result<(), Self::Error>
     where
         O: AsMut<[Operation<'a>]> 
     {

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -91,10 +91,7 @@ where
 {
     type Error = Error<SpiError, PinError>;
 
-    fn exec<'a, O>(&mut self, operations: O) -> Result<(), Self::Error>
-    where
-        O: AsMut<[Operation<'a, u8>]> 
-    {
+    fn exec<'a>(&mut self, operations: &mut [spi::Operation<'a, u8>]) -> Result<(), Self::Error> {
         self.cs.set_low().map_err(Error::Pin)?;
 
         let r = spi::Transactional::exec(&mut self.spi, operations).map_err(Error::Spi);

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -21,7 +21,7 @@ pub struct Wrapper<Spi, SpiError, CsPin, BusyPin, ReadyPin, ResetPin, PinError, 
 
     delay: Delay,
 
-    _e: std::marker::PhantomData<Error<SpiError, PinError>>,
+    _e: core::marker::PhantomData<Error<SpiError, PinError>>,
 }
 
 /// ManagedChipSelect indicates wrapper controls CS line
@@ -35,7 +35,7 @@ where
 
     /// Create a new wrapper with the provided chip select pin
     pub fn new(spi: Spi, cs: CsPin, reset: ResetPin, busy: BusyPin, ready: ReadyPin, delay: Delay) -> Self {
-        Self{spi, cs, reset, busy, ready, delay, _e: std::marker::PhantomData}
+        Self{spi, cs, reset, busy, ready, delay, _e: core::marker::PhantomData}
     }
 
     /// Explicitly fetch the inner spi (non-CS controlling) object

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -183,7 +183,7 @@ pub fn spi_exec<'a, Spi, SpiError, Operations>(spi: &mut Spi, mut operations: Op
 
         match &mut t {
             Operation::Write(d) => spi.write(d)?,
-            Operation::WriteRead(d) => spi.transfer(d).map(|_| ())?,
+            Operation::Transfer(d) => spi.transfer(d).map(|_| ())?,
         }
     }
     Ok(())


### PR DESCRIPTION
Re-worked the wrapper type to use the new transactional SPI api, reworked `Hal` abstraction and added `hal-linux` and `hal-cp2130` implementations.

Added an example `ManagedChipSelect` trait and updated `Wrapper` to re-expose SPI devices with this trait as proposed in https://github.com/rust-embedded/embedded-hal/issues/180

Todo:
- [ ] Document HAL / justification / usage
- [ ] Test new API in existing radio drivers
- [ ] Revert from patches to released crates (once upstream PRs have landed)
- [ ] Clean up any `unimplemented!()`

Blocked on:
- [ ] https://github.com/rust-embedded/embedded-hal/pull/178
- [ ] https://github.com/rust-embedded/linux-embedded-hal/pull/33

cc. @berkowski in case you're interested in the changes