### PR TITLE
WIP: Deps/embedded hal 1.0.0 alpha.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ structopt = { version = "0.3.11", optional = true }
 simplelog = { version = "0.8.0", optional = true }
 
 [dependencies.embedded-hal]
-version = "1.0.0-alpha.7"
+version = "1.0.0-alpha.8"
 
 [dependencies.linux-embedded-hal]
 version = "0.4.0-alpha.2"

--- a/src/hal/mod.rs
+++ b/src/hal/mod.rs
@@ -153,21 +153,7 @@ pub enum HalSpi {
     Cp2130(driver_cp2130::Spi),
 }
 
-impl embedded_hal::spi::blocking::TransferInplace<u8> for HalSpi {
-
-    fn transfer_inplace<'w>(&mut self, data: &'w mut [u8]) -> Result<(), Self::Error> {
-        match self {
-            #[cfg(all(feature = "hal-linux", target_os = "linux"))]
-            HalSpi::Linux(i) => i.transfer_inplace(data)?,
-            #[cfg(feature = "hal-cp2130")]
-            HalSpi::Cp2130(i) => i.transfer_inplace(data)?,
-            _ => return Err(HalError::NoDriver)
-        }
-        Ok(())
-    }
-}
-
-impl embedded_hal::spi::blocking::Transfer<u8> for HalSpi {
+impl embedded_hal::spi::blocking::SpiBus<u8> for HalSpi {
 
     fn transfer<'w>(&mut self, buff: &'w mut [u8], data: &'w [u8]) -> Result<(), Self::Error> {
         match self {
@@ -179,9 +165,46 @@ impl embedded_hal::spi::blocking::Transfer<u8> for HalSpi {
         }
         Ok(())
     }
+
+    fn transfer_in_place<'w>(&mut self, data: &'w mut [u8]) -> Result<(), Self::Error> {
+        match self {
+            #[cfg(all(feature = "hal-linux", target_os = "linux"))]
+            HalSpi::Linux(i) => i.transfer_in_place(data)?,
+            #[cfg(feature = "hal-cp2130")]
+            HalSpi::Cp2130(i) => i.transfer_in_place(data)?,
+            _ => return Err(HalError::NoDriver)
+        }
+        Ok(())
+    }
 }
 
-impl embedded_hal::spi::blocking::Write<u8> for HalSpi {
+impl embedded_hal::spi::blocking::SpiBusFlush for HalSpi {
+    fn flush(&mut self) -> Result<(), Self::Error> {
+        match self {
+            #[cfg(all(feature = "hal-linux", target_os = "linux"))]
+            HalSpi::Linux(i) => i.flush()?,
+            #[cfg(feature = "hal-cp2130")]
+            HalSpi::Cp2130(i) => i.flush()?,
+            _ => return Err(HalError::NoDriver)
+        }
+        Ok(())
+    }
+}
+
+impl embedded_hal::spi::blocking::SpiBusRead<u8> for HalSpi {
+    fn read<'w>(&mut self, data: &mut [u8]) -> Result<(), Self::Error> {
+        match self {
+            #[cfg(all(feature = "hal-linux", target_os = "linux"))]
+            HalSpi::Linux(i) => i.read(data)?,
+            #[cfg(feature = "hal-cp2130")]
+            HalSpi::Cp2130(i) => i.read(data)?,
+            _ => return Err(HalError::NoDriver)
+        }
+        Ok(())
+    }
+}
+
+impl embedded_hal::spi::blocking::SpiBusWrite<u8> for HalSpi {
 
     fn write<'w>(&mut self, data: &[u8]) -> Result<(), Self::Error> {
         match self {
@@ -197,22 +220,6 @@ impl embedded_hal::spi::blocking::Write<u8> for HalSpi {
 
 impl embedded_hal::spi::ErrorType for HalSpi {
     type Error = HalError;
-}
-
-use embedded_hal::spi::blocking::Operation;
-
-impl embedded_hal::spi::blocking::Transactional<u8> for HalSpi {
-
-    fn exec<'b>(&mut self, operations: &mut [Operation<'b, u8>]) -> Result<(), Self::Error> {
-        match self {
-            #[cfg(all(feature = "hal-linux", target_os = "linux"))]
-            HalSpi::Linux(i) => i.exec(operations)?,
-            #[cfg(feature = "hal-cp2130")]
-            HalSpi::Cp2130(i) => i.exec(operations)?,
-            _ => todo!()
-        }
-        Ok(())
-    }
 }
 
 /// Input pin hal wrapper

--- a/src/hal/mod.rs
+++ b/src/hal/mod.rs
@@ -154,14 +154,13 @@ pub enum HalSpi {
 }
 
 impl embedded_hal::spi::blocking::SpiBus<u8> for HalSpi {
-
     fn transfer<'w>(&mut self, buff: &'w mut [u8], data: &'w [u8]) -> Result<(), Self::Error> {
         match self {
             #[cfg(all(feature = "hal-linux", target_os = "linux"))]
             HalSpi::Linux(i) => i.transfer(buff, data)?,
             #[cfg(feature = "hal-cp2130")]
             HalSpi::Cp2130(i) => i.transfer(buff, data)?,
-            _ => return Err(HalError::NoDriver)
+            _ => return Err(HalError::NoDriver),
         }
         Ok(())
     }
@@ -172,7 +171,7 @@ impl embedded_hal::spi::blocking::SpiBus<u8> for HalSpi {
             HalSpi::Linux(i) => i.transfer_in_place(data)?,
             #[cfg(feature = "hal-cp2130")]
             HalSpi::Cp2130(i) => i.transfer_in_place(data)?,
-            _ => return Err(HalError::NoDriver)
+            _ => return Err(HalError::NoDriver),
         }
         Ok(())
     }
@@ -185,7 +184,7 @@ impl embedded_hal::spi::blocking::SpiBusFlush for HalSpi {
             HalSpi::Linux(i) => i.flush()?,
             #[cfg(feature = "hal-cp2130")]
             HalSpi::Cp2130(i) => i.flush()?,
-            _ => return Err(HalError::NoDriver)
+            _ => return Err(HalError::NoDriver),
         }
         Ok(())
     }
@@ -198,21 +197,20 @@ impl embedded_hal::spi::blocking::SpiBusRead<u8> for HalSpi {
             HalSpi::Linux(i) => i.read(data)?,
             #[cfg(feature = "hal-cp2130")]
             HalSpi::Cp2130(i) => i.read(data)?,
-            _ => return Err(HalError::NoDriver)
+            _ => return Err(HalError::NoDriver),
         }
         Ok(())
     }
 }
 
 impl embedded_hal::spi::blocking::SpiBusWrite<u8> for HalSpi {
-
     fn write<'w>(&mut self, data: &[u8]) -> Result<(), Self::Error> {
         match self {
             #[cfg(all(feature = "hal-linux", target_os = "linux"))]
             HalSpi::Linux(i) => i.write(data)?,
             #[cfg(feature = "hal-cp2130")]
             HalSpi::Cp2130(i) => i.write(data)?,
-            _ => return Err(HalError::NoDriver)
+            _ => return Err(HalError::NoDriver),
         }
         Ok(())
     }
@@ -233,12 +231,11 @@ pub enum HalInputPin {
 }
 
 impl embedded_hal::digital::blocking::InputPin for HalInputPin {
-
     fn is_high(&self) -> Result<bool, Self::Error> {
         let r = match self {
             #[cfg(all(feature = "hal-linux", target_os = "linux"))]
             HalInputPin::Linux(i) => i.is_high()?,
-            
+
             #[cfg(feature = "hal-cp2130")]
             HalInputPin::Cp2130(i) => i.is_high()?,
 
@@ -268,7 +265,6 @@ pub enum HalOutputPin {
 }
 
 impl embedded_hal::digital::blocking::OutputPin for HalOutputPin {
-
     fn set_high(&mut self) -> Result<(), Self::Error> {
         match self {
             #[cfg(all(feature = "hal-linux", target_os = "linux"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,13 +133,16 @@ pub enum Error<SpiError, PinError, DelayError> {
     Aborted,
 }
 
-impl<SpiError, PinError, DelayError> embedded_hal::spi::Error for Error<SpiError, PinError, DelayError>
-where 
+impl<SpiError, PinError, DelayError> embedded_hal::spi::Error
+    for Error<SpiError, PinError, DelayError>
+where
     SpiError: core::fmt::Debug,
     PinError: core::fmt::Debug,
     DelayError: core::fmt::Debug,
 {
-    fn kind(&self) -> embedded_hal::spi::ErrorKind { embedded_hal::spi::ErrorKind::Other }
+    fn kind(&self) -> embedded_hal::spi::ErrorKind {
+        embedded_hal::spi::ErrorKind::Other
+    }
 }
 
 /// PinState enum used for busy indication
@@ -176,11 +179,7 @@ where
     type Error = <T as embedded_hal::spi::ErrorType>::Error;
 
     /// Read data with the specified prefix
-    fn prefix_read<'a>(
-        &mut self,
-        prefix: &[u8],
-        data: &'a mut [u8],
-    ) -> Result<(), Self::Error> {
+    fn prefix_read<'a>(&mut self, prefix: &[u8], data: &'a mut [u8]) -> Result<(), Self::Error> {
         self.write(prefix)?;
         self.transfer_in_place(data)?;
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,8 @@ pub trait ManagedChipSelect {}
 pub trait Hal<E>:
     PrefixWrite<Error = E>
     + PrefixRead<Error = E>
-    + embedded_hal::spi::blocking::Transactional<u8, Error = E>
+    + embedded_hal::spi::blocking::SpiBusRead<u8, Error = E>
+    + embedded_hal::spi::blocking::SpiBusWrite<u8, Error = E>
     + Busy<Error = E>
     + Ready<Error = E>
     + Reset<Error = E>
@@ -64,7 +65,9 @@ pub trait Hal<E>:
 impl<T, E> Hal<E> for T where
     T: PrefixWrite<Error = E>
         + PrefixRead<Error = E>
-        + embedded_hal::spi::blocking::Transactional<u8, Error = E>
+        + embedded_hal::spi::blocking::SpiBusRead<u8, Error = E>
+        + embedded_hal::spi::blocking::SpiBusWrite<u8, Error = E>
+        //+ embedded_hal::spi::blocking::Transactional<u8, Error = E>
         + Busy<Error = E>
         + Ready<Error = E>
         + Reset<Error = E>
@@ -88,10 +91,6 @@ pub trait PrefixWrite {
     /// Write writes the prefix buffer then writes the output buffer
     fn prefix_write(&mut self, prefix: &[u8], data: &[u8]) -> Result<(), Self::Error>;
 }
-
-/// Transaction enum defines possible SPI transactions
-/// Re-exported from embedded-hal
-pub type Transaction<'a> = embedded_hal::spi::blocking::Operation<'a, u8>;
 
 /// Chip Select trait for peripherals supporting manual chip select
 pub trait ChipSelect {
@@ -150,22 +149,20 @@ pub enum PinState {
     High,
 }
 
-use embedded_hal::spi::blocking::{Transactional, Operation};
+use embedded_hal::spi::blocking::{SpiBus, SpiBusRead, SpiBusWrite};
 
 /// Automatic `driver_pal::PrefixWrite` implementation for objects implementing `embedded_hal::blocking::spi::Transactional`.
 impl<T> PrefixWrite for T
 where
-    T: Transactional<u8>,
+    T: SpiBusRead<u8> + SpiBusWrite<u8>,
     <T as embedded_hal::spi::ErrorType>::Error: core::fmt::Debug,
 {
     type Error = <T as embedded_hal::spi::ErrorType>::Error;
 
     /// Write data with the specified prefix
     fn prefix_write(&mut self, prefix: &[u8], data: &[u8]) -> Result<(), Self::Error> {
-        let mut ops = [Operation::Write(prefix), Operation::Write(data)];
-
-        self.exec(&mut ops)?;
-
+        self.write(prefix)?;
+        self.write(data)?;
         Ok(())
     }
 }
@@ -173,7 +170,7 @@ where
 /// Automatic `driver_pal::PrefixRead` implementation for objects implementing `embedded_hal::blocking::spi::Transactional`.
 impl<T> PrefixRead for T
 where
-    T: Transactional<u8>,
+    T: SpiBusWrite<u8> + SpiBus<u8>,
     <T as embedded_hal::spi::ErrorType>::Error: core::fmt::Debug,
 {
     type Error = <T as embedded_hal::spi::ErrorType>::Error;
@@ -184,13 +181,8 @@ where
         prefix: &[u8],
         data: &'a mut [u8],
     ) -> Result<(), Self::Error> {
-        let mut ops = [
-            Operation::Write(prefix),
-            Operation::TransferInplace(data),
-        ];
-
-        self.exec(&mut ops)?;
-
+        self.write(prefix)?;
+        self.transfer_in_place(data)?;
         Ok(())
     }
 }

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -311,7 +311,6 @@ impl embedded_hal::delay::blocking::DelayUs for Spi {
 }
 
 impl embedded_hal::spi::blocking::SpiBus<u8> for Spi {
-
     fn transfer_in_place<'w>(&mut self, data: &'w mut [u8]) -> Result<(), Self::Error> {
         let mut i = self.inner.lock().unwrap();
         let index = i.index;
@@ -386,7 +385,6 @@ impl embedded_hal::spi::blocking::SpiBusRead<u8> for Spi {
 }
 
 impl embedded_hal::spi::blocking::SpiBusWrite<u8> for Spi {
-
     fn write<'w>(&mut self, data: &[u8]) -> Result<(), Self::Error> {
         let mut i = self.inner.lock().unwrap();
 
@@ -405,7 +403,6 @@ impl embedded_hal::spi::ErrorType for Spi {
 }
 
 impl embedded_hal::digital::blocking::InputPin for Pin {
-
     fn is_high(&self) -> Result<bool, Self::Error> {
         let mut i = self.inner.lock().unwrap();
         let index = i.index;
@@ -446,7 +443,6 @@ impl embedded_hal::digital::blocking::InputPin for Pin {
 }
 
 impl embedded_hal::digital::blocking::OutputPin for Pin {
-
     fn set_high(&mut self) -> Result<(), Self::Error> {
         let mut i = self.inner.lock().unwrap();
 
@@ -476,7 +472,6 @@ impl embedded_hal::digital::ErrorType for Pin {
     type Error = PinError;
 }
 
-
 impl embedded_hal::delay::blocking::DelayUs for Delay {
     type Error = DelayError;
 
@@ -495,8 +490,8 @@ impl embedded_hal::delay::blocking::DelayUs for Delay {
 
 #[cfg(test)]
 mod test {
-    use std::*;
     use std::vec;
+    use std::*;
 
     use embedded_hal::digital::blocking::*;
     use embedded_hal::spi::blocking::*;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,3 @@
-
 use std::fs::read_to_string;
 use std::string::{String, ToString};
 
@@ -9,7 +8,7 @@ pub use simplelog::{LevelFilter, TermLogger};
 
 pub use embedded_hal::digital::v2::{InputPin, OutputPin};
 pub use linux_embedded_hal::sysfs_gpio::{Direction, Error as PinError};
-pub use linux_embedded_hal::{spidev, Delay, Pin as Pindev, Spidev, spidev::SpiModeFlags};
+pub use linux_embedded_hal::{spidev, spidev::SpiModeFlags, Delay, Pin as Pindev, Spidev};
 
 use crate::wrapper::Wrapper;
 
@@ -53,7 +52,9 @@ pub struct DeviceConfig {
 
 impl DeviceConfig {
     /// Load without busy or ready pins
-    pub fn load_base(&self) -> Wrapper<Spidev, std::io::Error, Pindev, (), (), Pindev, PinError, Delay> {
+    pub fn load_base(
+        &self,
+    ) -> Wrapper<Spidev, std::io::Error, Pindev, (), (), Pindev, PinError, Delay> {
         // Load SPI peripheral
         let spi = load_spi(&self.spi, self.baud, SpiModeFlags::SPI_MODE_0);
 

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -61,13 +61,12 @@ where
 }
 
 impl<Spi, CsPin, BusyPin, ReadyPin, ResetPin, Delay> embedded_hal::spi::ErrorType
-    for Wrapper<Spi, CsPin, BusyPin, ReadyPin, ResetPin, Delay> 
+    for Wrapper<Spi, CsPin, BusyPin, ReadyPin, ResetPin, Delay>
 where
     Spi: embedded_hal::spi::ErrorType,
     CsPin: embedded_hal::digital::ErrorType,
     Delay: DelayUs,
-    {
-
+{
     type Error = Error<
         <Spi as embedded_hal::spi::ErrorType>::Error,
         <CsPin as embedded_hal::digital::ErrorType>::Error,
@@ -76,13 +75,12 @@ where
 }
 
 impl<Spi, CsPin, BusyPin, ReadyPin, ResetPin, Delay> embedded_hal::digital::ErrorType
-    for Wrapper<Spi, CsPin, BusyPin, ReadyPin, ResetPin, Delay> 
+    for Wrapper<Spi, CsPin, BusyPin, ReadyPin, ResetPin, Delay>
 where
     Spi: embedded_hal::spi::ErrorType,
     CsPin: embedded_hal::digital::ErrorType,
     Delay: DelayUs,
-    {
-
+{
     type Error = Error<
         <Spi as embedded_hal::spi::ErrorType>::Error,
         <CsPin as embedded_hal::digital::ErrorType>::Error,
@@ -194,7 +192,7 @@ where
     BusyPin: InputPin,
 {
     type Error = <BusyPin as embedded_hal::digital::ErrorType>::Error;
-    
+
     /// Fetch the busy pin state
     fn get_busy(&mut self) -> Result<PinState, Self::Error> {
         match self.busy.is_high()? {


### PR DESCRIPTION
Bumps the embedded-hal version to 1.0.0-alpha.8.

Pending on the following dependencies:
- linux-embedded-hal: https://github.com/rust-embedded/linux-embedded-hal/pull/83
- rust-driver-cp2130: https://github.com/rust-iot/rust-driver-cp2130/pull/29